### PR TITLE
some small fixes to get disassembly working again

### DIFF
--- a/PyDA.py
+++ b/PyDA.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from interface import app
 from concurrent.futures import ThreadPoolExecutor
 from disassembler.Disassembler import Disassembler

--- a/disassembler/Disassembler.py
+++ b/disassembler/Disassembler.py
@@ -4,6 +4,7 @@ from settings import *
 class Disassembler:
     def __init__(self, settings_manager):
         self.settings_manager = settings_manager
+        self.dis = True # This was not defined in the appropriate scope.  breaks at if statement below when format doesn't match known type.
 
     def load(self, binary, filename = None):
         self.binary = binary

--- a/disassembler/formats/pe.py
+++ b/disassembler/formats/pe.py
@@ -1,3 +1,4 @@
+import capstone
 from capstone import *
 from disassembler.formats.common.program import CommonProgramDisassemblyFormat
 from disassembler.formats.common.section import CommonSectionFormat


### PR DESCRIPTION
I was getting errors when attempting to use the latest version to disassemble a bin.
self.dis was not defined prior to a if statement (which broke).
and then later capstone (itself) wasn't being imported directly (which broke).

both fixed and added shebang to the first line of PyDA.py so i don't have to feed the script to python manually on nix systems.

disassembly appears to be working again. :)
